### PR TITLE
Add Dockerfile for FastAPI app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY pyproject.toml .
+RUN pip install --no-cache-dir fastapi uvicorn httpx
+
+COPY FastAPI_Lab.py .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "FastAPI_Lab:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
Add a Dockerfile to containerize the FastAPI application. Uses python:3.11-slim, sets /app as workdir, copies pyproject.toml and FastAPI_Lab.py, installs fastapi, uvicorn and httpx, exposes port 8000 and starts the app with uvicorn (FastAPI_Lab:app).