### PR TITLE
chore: enable ruff auto-fix in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,5 +3,5 @@ repos:
     rev: v0.15.10
     hooks:
       - id: ruff-check
+        args: [--fix]
       - id: ruff-format
-        args: [--check]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,10 +24,10 @@ This project uses [pre-commit](https://pre-commit.com/) to run code checks autom
 
 Two hooks run on every commit:
 
-- **ruff-check** — checks for common Python errors, unused imports, and import ordering
-- **ruff-format** — checks that code follows consistent formatting
+- **ruff-check** — checks for common Python errors, unused imports, and import ordering, and auto-fixes issues where possible (runs with `--fix`)
+- **ruff-format** — reformats code to follow consistent style
 
-If a hook fails, the commit is blocked. Review the error output, fix the issue, `git add` your changes, and commit again.
+Both hooks modify your files in place when they find something to fix. Pre-commit then fails the commit so you can review the changes. Review the diff, `git add` the updated files, and commit again.
 
 ### Running checks manually
 


### PR DESCRIPTION
Add --fix to ruff-check and remove --check from ruff-format so both hooks modify files in place. Update CONTRIBUTING.md to describe the re-stage workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pre-commit hooks to automatically fix linting issues and reformat code during commit.

* **Documentation**
  * Updated contributing guide to reflect new pre-commit hook behavior, including guidance for reviewing auto-corrected changes before re-committing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->