### PR TITLE
ci: skip CI workflow when only docs/README/CONTRIBUTING change

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,16 @@ name: CI/CD
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - "docs/**"
+      - "README.md"
+      - "CONTRIBUTING.md"
   pull_request:
     branches: ["main"]
+    paths-ignore:
+      - "docs/**"
+      - "README.md"
+      - "CONTRIBUTING.md"
 
 jobs:
   lint-and-test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Notable changes to DocQFlow are recorded here so reviewers, teammates, and AI agents can quickly see what was added or changed and when.
 
+## 2026-04-27
+
+### Changed
+
+- CI: add `paths-ignore` to both `push` and `pull_request` triggers in `.github/workflows/test.yml` so the workflow does not run when the only changed paths are under `docs/`, `README.md`, or `CONTRIBUTING.md`. Saves runner minutes on doc-only changes.
+
 ## 2026-04-26
 
 ### Added


### PR DESCRIPTION
## summary
- adds `paths-ignore` to both the `push` and `pull_request` triggers in `.github/workflows/test.yml`
- patterns ignored: `docs/**`, `README.md`, `CONTRIBUTING.md`
- when a PR or push only changes those paths, the workflow does not trigger at all — zero runner minutes consumed
- any commit that touches a non-ignored path runs the workflow as normal

## why this approach
- `paths-ignore` is GitHub-native — no shell, no `git diff`, no edge cases. Cleaner than the previous step-level `if:` approach (~40 lines of bash) which has been swapped out.
- saves CI minutes on doc-only changes by skipping job startup entirely (matrix × Python 3.11 + 3.12 = 2 runners avoided per doc-only event).

## caveat to be aware of
- if `lint-and-test` is later added as a **required status check** in branch protection, doc-only PRs may be blocked because the check never reports. Mitigation if/when that happens: add a sibling "always-green" stub workflow with the inverse `paths` filter, or use *Required workflows* instead of *Required checks*. Not an issue today since branch protection is not enforcing this check.

## test plan
- [ ] CI runs on this PR — this PR touches `.github/workflows/test.yml` and `CHANGELOG.md`, neither of which is in `paths-ignore`, so the workflow **should** run normally and pass
- [ ] follow-up smoke test after merge: open a one-line `README.md` PR and confirm no CI run is triggered
- [ ] follow-up smoke test: open a `docs/foo.md` only PR and confirm no CI run is triggered

## related
- supersedes the heavier step-level approach originally proposed in this PR (replaced via force-push)
- builds alongside the existing changelog-guard logic from #15