### PR TITLE
gcs bucket setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,7 @@ SUPABASE_URL=https://<ref>.supabase.co
 SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_ROLE_KEY=
 DATABASE_URL=postgresql://postgres:<password>@db.<ref>.supabase.co:5432/postgres
+
+# GCP
+GCP_PROJECT=docqflow
+GCS_BUCKET=docqflow-pdfs-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Notable changes to DocQFlow are recorded here so reviewers, teammates, and AI ag
 
 ### Added
 
+- GCS dev bucket setup: `docqflow-pdfs-dev` in `us-west1` with uniform bucket-level access, public access prevention, and a 30-day delete lifecycle. Service account `docqflow-api-dev` granted `roles/storage.objectAdmin` scoped to the bucket only. Workload Identity Federation pool `github-pool-dev` configured for `tomtranjr/docqflow` GitHub Actions — no static JSON keys.
+- `docs/setup/gcp.md`: project + APIs, bucket creation, lifecycle, optional CORS, service account IAM, WIF for GitHub Actions, local `gcloud auth application-default login`, and a smoke test.
+- `.env.example`: `GCP_PROJECT` and `GCS_BUCKET` placeholders.
 - Supabase dev project setup: `documents` and `pipeline_runs` tables under `supabase/migrations/`, with row-level security limiting access to `auth.uid() = uploaded_by` (and the matching join policy on `pipeline_runs`).
 - `docs/setup/supabase.md`: how to install the CLI, get credentials, run migrations locally (`supabase db reset`), push to dev (`supabase db push`), and add new migrations.
 - `.env.example`: `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `DATABASE_URL` placeholders.

--- a/docs/setup/gcp.md
+++ b/docs/setup/gcp.md
@@ -1,0 +1,143 @@
+# GCP Setup
+
+This guide walks you through getting GCP set up for docqflow dev. The bucket holds uploaded PDFs; Workload Identity Federation lets GitHub Actions and Cloud Run authenticate without static JSON keys.
+
+## Prerequisites
+
+- [`gcloud` CLI](https://cloud.google.com/sdk/docs/install) installed and on your PATH
+- Owner or editor access to the `docqflow` GCP project
+- A GitHub account with push access to `tomtranjr/docqflow`
+
+## Naming convention
+
+The GCP project is `docqflow`. Every resource inside it uses a `-dev` suffix to mark the dev environment.
+
+| Thing | Name |
+|---|---|
+| Project | `docqflow` |
+| Bucket | `docqflow-pdfs-dev` |
+| Service account | `docqflow-api-dev@docqflow.iam.gserviceaccount.com` |
+| WIF pool | `github-pool-dev` |
+| WIF provider | `github-provider-dev` |
+
+## Steps
+
+### 1. Set the active project and enable APIs
+
+```bash
+gcloud config set project docqflow
+gcloud services enable \
+  storage.googleapis.com \
+  iam.googleapis.com \
+  iamcredentials.googleapis.com \
+  secretmanager.googleapis.com \
+  run.googleapis.com \
+  artifactregistry.googleapis.com
+```
+
+### 2. Create the bucket
+
+```bash
+gcloud storage buckets create gs://docqflow-pdfs-dev \
+  --location=us-west1 \
+  --uniform-bucket-level-access \
+  --public-access-prevention
+```
+
+### 3. Apply the 30-day lifecycle rule
+
+Create `lifecycle.json`:
+
+```json
+{"lifecycle":{"rule":[{"action":{"type":"Delete"},"condition":{"age":30}}]}}
+```
+
+Apply it:
+
+```bash
+gcloud storage buckets update gs://docqflow-pdfs-dev --lifecycle-file=lifecycle.json
+```
+
+### 4. CORS (optional)
+
+Only needed if the frontend fetches signed URLs directly from GCS. Skip if the API streams PDFs through FastAPI.
+
+Create `cors.json`:
+
+```json
+[{"origin":["https://docqflow.vercel.app","http://localhost:3000"],
+  "method":["GET"],"responseHeader":["Content-Type"],"maxAgeSeconds":3600}]
+```
+
+Apply it:
+
+```bash
+gcloud storage buckets update gs://docqflow-pdfs-dev --cors-file=cors.json
+```
+
+### 5. Create the service account and grant bucket-scoped IAM
+
+```bash
+gcloud iam service-accounts create docqflow-api-dev \
+  --display-name="DocQFlow API (dev)"
+
+gcloud storage buckets add-iam-policy-binding gs://docqflow-pdfs-dev \
+  --member="serviceAccount:docqflow-api-dev@docqflow.iam.gserviceaccount.com" \
+  --role="roles/storage.objectAdmin"
+```
+
+The IAM binding is scoped to the bucket, not the project, so the SA can only touch this bucket.
+
+### 6. Configure Workload Identity Federation for GitHub Actions
+
+```bash
+gcloud iam workload-identity-pools create github-pool-dev \
+  --location=global --display-name="GitHub Actions (dev)"
+
+gcloud iam workload-identity-pools providers create-oidc github-provider-dev \
+  --location=global --workload-identity-pool=github-pool-dev \
+  --display-name="GitHub OIDC (dev)" \
+  --attribute-mapping="google.subject=assertion.sub,attribute.repository=assertion.repository" \
+  --attribute-condition="assertion.repository=='tomtranjr/docqflow'" \
+  --issuer-uri="https://token.actions.githubusercontent.com"
+
+PROJECT_NUMBER=$(gcloud projects describe docqflow --format='value(projectNumber)')
+
+gcloud iam service-accounts add-iam-policy-binding \
+  docqflow-api-dev@docqflow.iam.gserviceaccount.com \
+  --role=roles/iam.workloadIdentityUser \
+  --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/github-pool-dev/attribute.repository/tomtranjr/docqflow"
+```
+
+Save the provider resource name. GitHub Actions workflows reference it as `workload_identity_provider`.
+
+### 7. Local dev access
+
+```bash
+gcloud auth application-default login
+```
+
+This writes credentials to `~/.config/gcloud/application_default_credentials.json`. The Google Cloud client libraries pick them up automatically. No JSON key files in the repo.
+
+### 8. Set local env vars
+
+Copy the example file if you haven't already, then confirm the GCP block is present:
+
+```bash
+cp .env.example .env
+```
+
+```env
+GCP_PROJECT=docqflow
+GCS_BUCKET=docqflow-pdfs-dev
+```
+
+## Smoke test
+
+```bash
+echo "test" > /tmp/test.txt
+gcloud storage cp /tmp/test.txt gs://docqflow-pdfs-dev/test.txt
+gcloud storage rm gs://docqflow-pdfs-dev/test.txt
+```
+
+If both commands succeed, your local credentials and the bucket IAM binding are working.


### PR DESCRIPTION
Adds the dev GCS bucket `docqflow-pdfs-dev` for PDF blob storage and the GitHub Actions WIF setup.

- `docs/setup/gcp.md` — gcloud commands to reproduce
- `.env.example` — `GCP_PROJECT` and `GCS_BUCKET`

Bucket, service account, and WIF were provisioned manually via gcloud.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added Google Cloud Storage setup guide for development environment configuration.
  * Guide covers GCP bucket creation, service account setup, and secure authentication for CI/CD pipelines.

* **Chores**
  * Updated environment configuration template with required Google Cloud Platform variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->