### PR TITLE
feat: add llm credentials env vars, profile doc, and presence check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,8 @@ DATABASE_URL=postgresql://postgres:<password>@db.<ref>.supabase.co:5432/postgres
 # GCP
 GCP_PROJECT=docqflow
 GCS_BUCKET=docqflow-pdfs-dev
+
+# LLM
+LLM_DEFAULT_PROFILE=cloud-fast
+OPENAI_MODEL=gpt-4o-mini
+OPENAI_API_KEY=sk-...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 Notable changes to DocQFlow are recorded here so reviewers, teammates, and AI agents can quickly see what was added or changed and when.
 
+## 2026-05-04
+
+### Added
+
+- LLM credential plumbing for the extraction pipeline. `OPENAI_API_KEY` lives in Google Secret Manager (`openai-api-key`, project `docqflow`); the `docqflow-api-dev` service account has `roles/secretmanager.secretAccessor` so Cloud Run can read it. Local dev hydrates `.env` via `gcloud secrets versions access`.
+- `docs/llm-profiles.md`: documents the `cloud-fast` profile (OpenAI `gpt-4o-mini`, expected latency, expected cost) and the workflow for hydrating a local key from Secret Manager.
+- `scripts/check_llm_profiles.py`: env-only smoke check that verifies `OPENAI_API_KEY` is set and looks valid. No network call — keeps CI free and avoids burning OpenAI budget.
+- `.env.example`: `LLM_DEFAULT_PROFILE`, `OPENAI_MODEL`, `OPENAI_API_KEY` placeholders.
+
 ## 2026-05-02
 
 ### Added

--- a/docs/llm-profiles.md
+++ b/docs/llm-profiles.md
@@ -1,0 +1,33 @@
+# LLM profiles
+
+Named LLM configurations used by the app. Each profile pins a provider, model, and rough latency/cost expectations so calling code can pick a profile by name instead of hard-coding model strings.
+
+## cloud-fast
+
+Default profile for dev. Cheap, fast, good enough for extraction and summarization smoke tests.
+
+| Field | Value |
+|---|---|
+| Provider | OpenAI |
+| Model | `gpt-4o-mini` |
+| Expected latency | ~1–3s for short prompts |
+| Expected cost | ~$0.15 / 1M input tokens, ~$0.60 / 1M output tokens |
+| Selected via | `LLM_DEFAULT_PROFILE=cloud-fast` |
+
+## Credentials
+
+`OPENAI_API_KEY` lives in Google Secret Manager (`openai-api-key`, project `docqflow`). Cloud Run reads it via the `docqflow-api-dev` service account. For local dev:
+
+```bash
+echo "OPENAI_API_KEY=$(gcloud secrets versions access latest --secret=openai-api-key --project=docqflow)" >> .env
+```
+
+Never paste the key on the command line or commit it.
+
+## Verifying setup
+
+```bash
+python scripts/check_llm_profiles.py
+```
+
+Checks that `OPENAI_API_KEY` is present in the environment. Does not call OpenAI.

--- a/docs/llm-profiles.md
+++ b/docs/llm-profiles.md
@@ -19,10 +19,11 @@ Default profile for dev. Cheap, fast, good enough for extraction and summarizati
 `OPENAI_API_KEY` lives in Google Secret Manager (`openai-api-key`, project `docqflow`). Cloud Run reads it via the `docqflow-api-dev` service account. For local dev:
 
 ```bash
-echo "OPENAI_API_KEY=$(gcloud secrets versions access latest --secret=openai-api-key --project=docqflow)" >> .env
+# Check .env for existing OPENAI_API_KEY before appending to avoid duplicates
+gcloud secrets versions access latest --secret=openai-api-key --project=docqflow | sed 's/^/OPENAI_API_KEY=/' >> .env
 ```
 
-Never paste the key on the command line or commit it.
+Alternatively, use `--out-file`, Cloud Run secret injection, or tools like berglas or Chamber. Avoid typing secrets interactively if concerned about shell history. Never paste the key on the command line or commit it.
 
 ## Verifying setup
 

--- a/scripts/check_llm_profiles.py
+++ b/scripts/check_llm_profiles.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from dotenv import load_dotenv
 
@@ -16,7 +17,7 @@ def main():
 
     if not key or key == "sk-..." or not key.startswith("sk-"):
         print("status:  MISSING — OPENAI_API_KEY is not set to a real key")
-        return
+        sys.exit(1)
 
     print("status:  OK — OPENAI_API_KEY present")
 

--- a/scripts/check_llm_profiles.py
+++ b/scripts/check_llm_profiles.py
@@ -1,0 +1,25 @@
+import os
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def main():
+    """Verify LLM env vars are set. Env-only — does not call OpenAI."""
+    profile = os.getenv("LLM_DEFAULT_PROFILE", "<unset>")
+    model = os.getenv("OPENAI_MODEL", "<unset>")
+    key = os.getenv("OPENAI_API_KEY", "")
+
+    print(f"profile: {profile}")
+    print(f"model:   {model}")
+
+    if not key or key == "sk-..." or not key.startswith("sk-"):
+        print("status:  MISSING — OPENAI_API_KEY is not set to a real key")
+        return
+
+    print("status:  OK — OPENAI_API_KEY present")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## summary
- Add a `# LLM` section to `.env.example` documenting `LLM_DEFAULT_PROFILE`, `OPENAI_MODEL`, and `OPENAI_API_KEY` so contributors know which vars to populate
- Add `docs/llm-profiles.md` describing the `cloud-fast` profile (OpenAI, `gpt-4o-mini`, latency, cost) and the workflow for hydrating a local key from Google Secret Manager (`openai-api-key` in project `docqflow`, accessed by the `docqflow-api-dev` service account)
- Add `scripts/check_llm_profiles.py` — an env-only smoke check that prints whether `OPENAI_API_KEY` is present and looks valid. Mirrors the style of `scripts/check_mlflow.py` (uses `python-dotenv`).

## why
The extraction pipeline needs OpenAI access from both local dev and Cloud Run. This change establishes the credential surface (Secret Manager + env vars) and gives contributors a one-command way to verify their local setup without making an API call (no CI cost, no budget burn).

## test plan
- [x] `python scripts/check_llm_profiles.py` reports `status: OK` when key is present
- [x] Reports `MISSING` when key is unset or still the `sk-...` placeholder
- [x] No network call made (env-only)
- [x] Pre-commit hooks (ruff check, ruff format) pass

## scope
- In: env var documentation, profile reference doc, presence check
- Out: live OpenAI reachability check (deferred to LiteLLM integration), Anthropic profile, retry logic, billing alerts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LLM profile support with a cloud-fast default using gpt-4o-mini
  * Offline setup verification to ensure LLM credentials are present

* **Documentation**
  * Added LLM profiles docs with local secret-hydration guidance and verification steps
  * Updated changelog and environment sample to include LLM and cloud storage placeholders
<!-- end of auto-generated comment: release notes by coderabbit.ai -->