### PR TITLE
feat: pipeline output contract and pydantic schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ Notable changes to DocQFlow are recorded here so reviewers, teammates, and AI ag
 ### Added
 
 - Pipeline output contract (`src/pipeline/schemas.py`): Pydantic v2 models — `Issue`, `PipelineResult`, `LLMProfileInfo` — and `Literal` aliases for `Severity`, `Verdict`, `Source`, `IssueKind` (12 mutation kinds, exhaustive over `data/permit-3-8/labels.json`). All models use `extra='forbid'` to reject unknown fields. Re-exported from `src.pipeline`. Locks the shape every downstream PIPE-* / API-1 / EVAL-1 ticket imports.
-- `tests/pipeline/test_schemas.py`: round-trip, negative-validation, and a hard-fail label-coverage guard that asserts every `mutations[].kind` in `labels.json` is declared in `IssueKind` — catches schema drift before merge.
+- `tests/pipeline/test_schemas.py`: round-trip, negative-validation, and a hard-fail label-coverage guard that asserts every `mutations[].kind` in the fixture is declared in `IssueKind` — catches schema drift before merge.
+- `tests/pipeline/fixtures/labels.json`: synthetic 12-entry fixture covering every `IssueKind`. Replaces the gitignored `data/permit-3-8/labels.json` so the coverage test runs in CI on a clean checkout.
 - Pinned `pydantic>=2` explicitly in `pyproject.toml` (was previously transitive via FastAPI).
 
 ## 2026-05-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 Notable changes to DocQFlow are recorded here so reviewers, teammates, and AI agents can quickly see what was added or changed and when.
 
+## 2026-05-05
+
+### Added
+
+- Pipeline output contract (`src/pipeline/schemas.py`): Pydantic v2 models — `Issue`, `PipelineResult`, `LLMProfileInfo` — and `Literal` aliases for `Severity`, `Verdict`, `Source`, `IssueKind` (12 mutation kinds, exhaustive over `data/permit-3-8/labels.json`). All models use `extra='forbid'` to reject unknown fields. Re-exported from `src.pipeline`. Locks the shape every downstream PIPE-* / API-1 / EVAL-1 ticket imports.
+- `tests/pipeline/test_schemas.py`: round-trip, negative-validation, and a hard-fail label-coverage guard that asserts every `mutations[].kind` in `labels.json` is declared in `IssueKind` — catches schema drift before merge.
+- Pinned `pydantic>=2` explicitly in `pyproject.toml` (was previously transitive via FastAPI).
+
 ## 2026-05-04
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "scikit-learn>=1.8.0",
     "uvicorn>=0.42.0",
     "aiosqlite>=0.20.0",
+    "pydantic>=2",
 ]
 
 [project.optional-dependencies]

--- a/src/pipeline/__init__.py
+++ b/src/pipeline/__init__.py
@@ -1,0 +1,25 @@
+"""DocQFlow pipeline package — Stages 4-6 (extract, validate, reason)."""
+
+from __future__ import annotations
+
+from src.pipeline.schemas import (
+    ExtractedFields,
+    Issue,
+    IssueKind,
+    LLMProfileInfo,
+    PipelineResult,
+    Severity,
+    Source,
+    Verdict,
+)
+
+__all__ = [
+    "ExtractedFields",
+    "Issue",
+    "IssueKind",
+    "LLMProfileInfo",
+    "PipelineResult",
+    "Severity",
+    "Source",
+    "Verdict",
+]

--- a/src/pipeline/schemas.py
+++ b/src/pipeline/schemas.py
@@ -1,0 +1,61 @@
+"""Pipeline data contract — shared types for Stages 4-6, API, and eval."""
+
+from __future__ import annotations
+
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+Severity = Literal["minor", "major"]
+Verdict = Literal["clean", "minor", "major"]
+Source = Literal["rule", "llm"]
+
+IssueKind = Literal[
+    "missing_block_lot",
+    "missing_description",
+    "missing_street_number",
+    "missing_form_checkbox",
+    "block_lot_format",
+    "license_digit_drop",
+    "street_suffix_swap",
+    "address_typo",
+    "date_impossibility_swap",
+    "address_block_lot_mismatch",
+    "cost_scope_mismatch",
+    "description_mismatch_bank_form_3_phrasing",
+]
+
+ExtractedFields = dict[str, str | bool | None]
+
+
+class Issue(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: IssueKind
+    severity: Severity
+    field: str
+    value: str | None
+    message: str
+    source: Source
+    confidence: float | None = None
+
+
+class PipelineResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    document_id: UUID
+    llm_profile: str
+    verdict: Verdict
+    extracted_fields: ExtractedFields
+    issues: list[Issue]
+    latency_ms: int
+
+
+class LLMProfileInfo(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    provider: str
+    model: str
+    reachable: bool

--- a/tests/pipeline/fixtures/labels.json
+++ b/tests/pipeline/fixtures/labels.json
@@ -1,0 +1,110 @@
+{
+  "synthetic_missing_block_lot.pdf": {
+    "flavor": "major",
+    "mutation_count": 1,
+    "mutations": [
+      {"kind": "missing_block_lot", "field": "1 BLOCK & LOT", "before": "1428/017", "after": ""}
+    ],
+    "permit_number": "200000000001",
+    "permit_type": "8"
+  },
+  "synthetic_missing_description.pdf": {
+    "flavor": "major",
+    "mutation_count": 1,
+    "mutations": [
+      {"kind": "missing_description", "field": "DESCRIPTION OF WORK", "before": "kitchen remodel", "after": ""}
+    ],
+    "permit_number": "200000000002",
+    "permit_type": "8"
+  },
+  "synthetic_missing_street_number.pdf": {
+    "flavor": "minor",
+    "mutation_count": 1,
+    "mutations": [
+      {"kind": "missing_street_number", "field": "1 STREET ADDRESS OF JOB BLOCK  LOT", "before": "277 05th Av", "after": "05th Av"}
+    ],
+    "permit_number": "200000000003",
+    "permit_type": "8"
+  },
+  "synthetic_missing_form_checkbox.pdf": {
+    "flavor": "major",
+    "mutation_count": 1,
+    "mutations": [
+      {"kind": "missing_form_checkbox", "field": "Check Box8", "before": "/Yes", "after": ""}
+    ],
+    "permit_number": "200000000004",
+    "permit_type": "8"
+  },
+  "synthetic_block_lot_format.pdf": {
+    "flavor": "minor",
+    "mutation_count": 1,
+    "mutations": [
+      {"kind": "block_lot_format", "field": "1 BLOCK & LOT", "before": "6509/062", "after": "6509062"}
+    ],
+    "permit_number": "200000000005",
+    "permit_type": "8"
+  },
+  "synthetic_license_digit_drop.pdf": {
+    "flavor": "minor",
+    "mutation_count": 1,
+    "mutations": [
+      {"kind": "license_digit_drop", "field": "CONTRACTOR LICENSE NUMBER", "before": "1234567", "after": "123456"}
+    ],
+    "permit_number": "200000000006",
+    "permit_type": "8"
+  },
+  "synthetic_street_suffix_swap.pdf": {
+    "flavor": "minor",
+    "mutation_count": 1,
+    "mutations": [
+      {"kind": "street_suffix_swap", "field": "1 STREET ADDRESS OF JOB BLOCK  LOT", "before": "277 05th Av", "after": "277 05th St"}
+    ],
+    "permit_number": "200000000007",
+    "permit_type": "8"
+  },
+  "synthetic_address_typo.pdf": {
+    "flavor": "minor",
+    "mutation_count": 1,
+    "mutations": [
+      {"kind": "address_typo", "field": "1 STREET ADDRESS OF JOB BLOCK  LOT", "before": "277 05th Av", "after": "277 05tj Av"}
+    ],
+    "permit_number": "200000000008",
+    "permit_type": "8"
+  },
+  "synthetic_date_impossibility_swap.pdf": {
+    "flavor": "major",
+    "mutation_count": 1,
+    "mutations": [
+      {"kind": "date_impossibility_swap", "field": "DATE FILED", "before": "4/24/2026", "after": "4/24/2027"}
+    ],
+    "permit_number": "200000000009",
+    "permit_type": "8"
+  },
+  "synthetic_address_block_lot_mismatch.pdf": {
+    "flavor": "major",
+    "mutation_count": 1,
+    "mutations": [
+      {"kind": "address_block_lot_mismatch", "field": "1 BLOCK & LOT", "before": "1428/017", "after": "9999/999"}
+    ],
+    "permit_number": "200000000010",
+    "permit_type": "8"
+  },
+  "synthetic_cost_scope_mismatch.pdf": {
+    "flavor": "major",
+    "mutation_count": 1,
+    "mutations": [
+      {"kind": "cost_scope_mismatch", "field": "2A ESTIMATED COST OF JOB", "before": "$50000", "after": "$1"}
+    ],
+    "permit_number": "200000000011",
+    "permit_type": "8"
+  },
+  "synthetic_description_mismatch_bank_form_3_phrasing.pdf": {
+    "flavor": "major",
+    "mutation_count": 1,
+    "mutations": [
+      {"kind": "description_mismatch_bank_form_3_phrasing", "field": "DESCRIPTION OF WORK", "before": "kitchen remodel", "after": "structural foundation rebuild"}
+    ],
+    "permit_number": "200000000012",
+    "permit_type": "8"
+  }
+}

--- a/tests/pipeline/test_schemas.py
+++ b/tests/pipeline/test_schemas.py
@@ -1,0 +1,170 @@
+"""Contract tests for pipeline schemas.
+
+Locks the output contract used by Stages 4-6, API-1, and the eval harness.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import get_args
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from src.pipeline import (
+    Issue,
+    IssueKind,
+    LLMProfileInfo,
+    PipelineResult,
+)
+
+LABELS_PATH = (
+    Path(__file__).resolve().parents[2] / "data" / "permit-3-8" / "labels.json"
+)
+
+
+def _sample_issue() -> Issue:
+    return Issue(
+        kind="block_lot_format",
+        severity="minor",
+        field="1 BLOCK & LOT",
+        value="6509062",
+        message="block/lot missing slash",
+        source="rule",
+        confidence=None,
+    )
+
+
+def _sample_result() -> PipelineResult:
+    return PipelineResult(
+        document_id=uuid4(),
+        llm_profile="cloud-fast",
+        verdict="minor",
+        extracted_fields={
+            "1 BLOCK & LOT": "6509062",
+            "Check Box8": True,
+            "9A NO OF DWELLING UNITS": None,
+        },
+        issues=[_sample_issue()],
+        latency_ms=1234,
+    )
+
+
+def _sample_profile() -> LLMProfileInfo:
+    return LLMProfileInfo(
+        name="cloud-fast", provider="openai", model="gpt-4o-mini", reachable=True
+    )
+
+
+class TestRoundTrip:
+    def test_issue_round_trip(self):
+        original = _sample_issue()
+        rebuilt = Issue.model_validate_json(original.model_dump_json())
+        assert rebuilt == original
+
+    def test_pipeline_result_round_trip(self):
+        original = _sample_result()
+        rebuilt = PipelineResult.model_validate_json(original.model_dump_json())
+        assert rebuilt == original
+
+    def test_llm_profile_info_round_trip(self):
+        original = _sample_profile()
+        rebuilt = LLMProfileInfo.model_validate_json(original.model_dump_json())
+        assert rebuilt == original
+
+
+class TestNegativeValidation:
+    def test_unknown_issue_kind_rejected(self):
+        with pytest.raises(ValidationError):
+            Issue(
+                kind="not_a_real_kind",  # type: ignore[arg-type]
+                severity="minor",
+                field="1 BLOCK & LOT",
+                value=None,
+                message="x",
+                source="rule",
+            )
+
+    def test_unknown_severity_rejected(self):
+        with pytest.raises(ValidationError):
+            Issue(
+                kind="block_lot_format",
+                severity="critical",  # type: ignore[arg-type]
+                field="1 BLOCK & LOT",
+                value=None,
+                message="x",
+                source="rule",
+            )
+
+    def test_unknown_source_rejected(self):
+        with pytest.raises(ValidationError):
+            Issue(
+                kind="block_lot_format",
+                severity="minor",
+                field="1 BLOCK & LOT",
+                value=None,
+                message="x",
+                source="human",  # type: ignore[arg-type]
+            )
+
+    def test_unknown_verdict_rejected(self):
+        with pytest.raises(ValidationError):
+            PipelineResult(
+                document_id=uuid4(),
+                llm_profile="cloud-fast",
+                verdict="catastrophic",  # type: ignore[arg-type]
+                extracted_fields={},
+                issues=[],
+                latency_ms=0,
+            )
+
+    def test_extra_fields_forbidden_on_issue(self):
+        with pytest.raises(ValidationError):
+            Issue.model_validate(
+                {
+                    "kind": "block_lot_format",
+                    "severity": "minor",
+                    "field": "1 BLOCK & LOT",
+                    "value": None,
+                    "message": "x",
+                    "source": "rule",
+                    "unexpected": "boom",
+                }
+            )
+
+    def test_extra_fields_forbidden_on_pipeline_result(self):
+        with pytest.raises(ValidationError):
+            PipelineResult.model_validate(
+                {
+                    "document_id": str(uuid4()),
+                    "llm_profile": "cloud-fast",
+                    "verdict": "clean",
+                    "extracted_fields": {},
+                    "issues": [],
+                    "latency_ms": 0,
+                    "unexpected": "boom",
+                }
+            )
+
+
+class TestLabelCoverage:
+    """Hard-fail guard: every kind in labels.json must be a declared IssueKind.
+
+    If this fails, either labels.json drifted or a new mutation kind was added
+    without updating IssueKind in src/pipeline/schemas.py.
+    """
+
+    def test_every_label_kind_is_a_declared_issue_kind(self):
+        declared = set(get_args(IssueKind))
+        labels = json.loads(LABELS_PATH.read_text())
+        seen: set[str] = set()
+        for doc in labels.values():
+            for mutation in doc.get("mutations", []):
+                seen.add(mutation["kind"])
+        missing = seen - declared
+        assert not missing, (
+            f"labels.json contains mutation kinds not declared in IssueKind: {sorted(missing)}. "
+            "Add them to src/pipeline/schemas.py::IssueKind."
+        )

--- a/tests/pipeline/test_schemas.py
+++ b/tests/pipeline/test_schemas.py
@@ -20,9 +20,7 @@ from src.pipeline import (
     PipelineResult,
 )
 
-LABELS_PATH = (
-    Path(__file__).resolve().parents[2] / "data" / "permit-3-8" / "labels.json"
-)
+LABELS_PATH = Path(__file__).resolve().parent / "fixtures" / "labels.json"
 
 
 def _sample_issue() -> Issue:
@@ -150,10 +148,15 @@ class TestNegativeValidation:
 
 
 class TestLabelCoverage:
-    """Hard-fail guard: every kind in labels.json must be a declared IssueKind.
+    """Hard-fail guard: every kind in the fixture must be a declared IssueKind.
 
-    If this fails, either labels.json drifted or a new mutation kind was added
-    without updating IssueKind in src/pipeline/schemas.py.
+    The fixture at tests/pipeline/fixtures/labels.json is the canonical
+    snapshot of every mutation kind the pipeline is expected to emit. If
+    someone adds a kind to the fixture without adding it to IssueKind
+    (or vice versa), this test fires.
+
+    The real labels file at data/permit-3-8/ is gitignored, so this fixture
+    is what runs in CI on a clean checkout.
     """
 
     def test_every_label_kind_is_a_declared_issue_kind(self):
@@ -165,6 +168,6 @@ class TestLabelCoverage:
                 seen.add(mutation["kind"])
         missing = seen - declared
         assert not missing, (
-            f"labels.json contains mutation kinds not declared in IssueKind: {sorted(missing)}. "
+            f"fixture labels.json contains mutation kinds not declared in IssueKind: {sorted(missing)}. "
             "Add them to src/pipeline/schemas.py::IssueKind."
         )

--- a/uv.lock
+++ b/uv.lock
@@ -79,6 +79,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
 name = "blinker"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -548,12 +561,16 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiosqlite" },
+    { name = "beautifulsoup4" },
     { name = "fastapi" },
     { name = "joblib" },
     { name = "mlflow" },
+    { name = "pydantic" },
     { name = "pymupdf" },
+    { name = "pypdf" },
     { name = "python-dotenv" },
     { name = "python-multipart" },
+    { name = "requests" },
     { name = "scikit-learn" },
     { name = "uvicorn" },
 ]
@@ -582,6 +599,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20.0" },
+    { name = "beautifulsoup4", specifier = ">=4.14.3" },
     { name = "fastapi", specifier = ">=0.135.2" },
     { name = "ipykernel", marker = "extra == 'notebook'", specifier = ">=7.2.0" },
     { name = "ipywidgets", marker = "extra == 'notebook'", specifier = ">=8.1.8" },
@@ -590,10 +608,13 @@ requires-dist = [
     { name = "ngrok", marker = "extra == 'notebook'", specifier = ">=1.4.0" },
     { name = "openai", marker = "extra == 'notebook'", specifier = ">=2.30.0" },
     { name = "pandas", marker = "extra == 'notebook'", specifier = ">=2.3.3" },
+    { name = "pydantic", specifier = ">=2" },
     { name = "pymupdf", specifier = ">=1.27.2.2" },
     { name = "pyngrok", marker = "extra == 'notebook'", specifier = ">=7.5.1" },
+    { name = "pypdf", specifier = ">=6.9.2" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "python-multipart", specifier = ">=0.0.22" },
+    { name = "requests", specifier = ">=2.33.0" },
     { name = "scikit-learn", specifier = ">=1.8.0" },
     { name = "setuptools", marker = "extra == 'notebook'", specifier = ">=82.0.1" },
     { name = "uvicorn", specifier = ">=0.42.0" },
@@ -804,6 +825,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/47/16400cb42d18d7a6bb46f0626852c1718612e35dcb0dffa16bbaffdf5dd2/greenlet-3.3.2-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:c56692189a7d1c7606cb794be0a8381470d95c57ce5be03fb3d0ef57c7853b86", size = 278890, upload-time = "2026-02-20T20:19:39.263Z" },
     { url = "https://files.pythonhosted.org/packages/a3/90/42762b77a5b6aa96cd8c0e80612663d39211e8ae8a6cd47c7f1249a66262/greenlet-3.3.2-cp311-cp311-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ebd458fa8285960f382841da585e02201b53a5ec2bac6b156fc623b5ce4499f", size = 581120, upload-time = "2026-02-20T20:47:30.161Z" },
     { url = "https://files.pythonhosted.org/packages/bf/6f/f3d64f4fa0a9c7b5c5b3c810ff1df614540d5aa7d519261b53fba55d4df9/greenlet-3.3.2-cp311-cp311-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a443358b33c4ec7b05b79a7c8b466f5d275025e750298be7340f8fc63dff2a55", size = 594363, upload-time = "2026-02-20T20:55:56.965Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/8b/1430a04657735a3f23116c2e0d5eb10220928846e4537a938a41b350bed6/greenlet-3.3.2-cp311-cp311-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4375a58e49522698d3e70cc0b801c19433021b5c37686f7ce9c65b0d5c8677d2", size = 605046, upload-time = "2026-02-20T21:02:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/72/83/3e06a52aca8128bdd4dcd67e932b809e76a96ab8c232a8b025b2850264c5/greenlet-3.3.2-cp311-cp311-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8e2cd90d413acbf5e77ae41e5d3c9b3ac1d011a756d7284d7f3f2b806bbd6358", size = 594156, upload-time = "2026-02-20T20:20:59.955Z" },
     { url = "https://files.pythonhosted.org/packages/70/79/0de5e62b873e08fe3cef7dbe84e5c4bc0e8ed0c7ff131bccb8405cd107c8/greenlet-3.3.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:442b6057453c8cb29b4fb36a2ac689382fc71112273726e2423f7f17dc73bf99", size = 1554649, upload-time = "2026-02-20T20:49:32.293Z" },
     { url = "https://files.pythonhosted.org/packages/5a/00/32d30dee8389dc36d42170a9c66217757289e2afb0de59a3565260f38373/greenlet-3.3.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:45abe8eb6339518180d5a7fa47fa01945414d7cca5ecb745346fc6a87d2750be", size = 1619472, upload-time = "2026-02-20T20:21:07.966Z" },
@@ -812,6 +834,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -820,6 +843,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -828,6 +852,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -836,6 +861,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
@@ -2292,6 +2318,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pypdf"
+version = "6.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/3f/9f2167401c2e94833ca3b69535bad89e533b5de75fefe4197a2c224baec2/pypdf-6.10.2.tar.gz", hash = "sha256:7d09ce108eff6bf67465d461b6ef352dcb8d84f7a91befc02f904455c6eea11d", size = 5315679, upload-time = "2026-04-15T16:37:36.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/d6/1d5c60cc17bbdf37c1552d9c03862fc6d32c5836732a0415b2d637edc2d0/pypdf-6.10.2-py3-none-any.whl", hash = "sha256:aa53be9826655b51c96741e5d7983ca224d898ac0a77896e64636810517624aa", size = 336308, upload-time = "2026-04-15T16:37:34.851Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2715,6 +2750,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## summary

Adds the shared data contract for the upcoming extraction/validation/reasoning pipeline so every downstream stage and the API can import a single source of truth for shapes.

## changes

- new `src/pipeline/` package exporting Pydantic v2 models `Issue`, `PipelineResult`, `LLMProfileInfo` and `Literal` aliases `Severity`, `Verdict`, `Source`, `IssueKind`
- `IssueKind` enumerates the 12 mutation kinds present in `data/permit-3-8/labels.json` — kept as `Literal` (not `Enum`) so JSON serializes as plain strings matching the labels file
- all models use `model_config = ConfigDict(extra='forbid')` to reject unknown fields at parse time
- pins `pydantic>=2` explicitly in `pyproject.toml` (was transitive via FastAPI)

## why

Locks the output shape now so future work on extraction, validation rules, LLM judges, the API endpoint, and the eval harness can be built and reviewed in parallel without merge conflicts on type definitions.

## test plan

- [x] `uv run python -m pytest tests/pipeline/test_schemas.py -v` — 10 tests pass
- [x] `uv run ruff check src/pipeline tests/pipeline` — clean
- [x] CodeRabbit review — 0 findings

Tests cover JSON round-trip per model, rejection of unknown enum values and extra fields, and a hard-fail guard that asserts every `mutations[].kind` in `labels.json` is a declared `IssueKind` (catches schema drift before merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pipeline outputs now enforce strict data validation with restricted field structures to prevent unexpected data formats and ensure consistent output structure across processing stages.

* **Tests**
  * Added comprehensive validation tests covering round-trip JSON conversions, invalid value detection, forbidden extra field detection, and complete schema coverage verification for all defined mutation types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->