### PR TITLE
feat: stage 6 LLM reasoning (cost_scope + description)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Notable changes to DocQFlow are recorded here so reviewers, teammates, and AI agents can quickly see what was added or changed and when.
 
+## 2026-05-07
+
+### Added
+
+- Stage 6 LLM reasoning (`src/pipeline/reason.py`): two LLM-judged rules — `judge_cost_scope` (kind `cost_scope_mismatch`, judges `'2A ESTIMATED COST OF JOB'` against `'7A PRESENT USE'` and the description fields) and `judge_description` (kind `description_mismatch_bank_form_3_phrasing`, judges the description against the Form 3 / Form 8 selection encoded by `Check Box8` / `Check Box9`). Both call `judge()` from `llm_profiles` with a `JudgeResponse` Pydantic schema (`verdict ∈ {ok, flag}`, `confidence ∈ [0,1]`, `message`). Results below a configurable confidence threshold (default `0.6`) are suppressed. `run_reasoning(fields, profile)` runs both concurrently via `asyncio.gather(return_exceptions=True)` and never raises into the orchestrator: on `LLMTimeout` it emits an `Issue(source='llm', severity='major', confidence=None, message='LLM timeout — manual review required')` so the verdict rollup can route the document to manual review; `LLMSchemaError` and unexpected exceptions are logged and skipped. Re-exported from `src.pipeline`.
+- `tests/pipeline/test_reason.py`: 17 tests with `judge()` mocked at the boundary — no live LLM traffic. Covers clean / flagged / low-confidence-suppressed / timeout / schema-error paths for each judge, threshold override, prompt-content assertions (cost prompt includes cost + present-use + description; description prompt reflects which form is selected), and `run_reasoning` aggregation including the never-raises invariant when an unexpected exception is raised inside a judge.
+
 ## 2026-05-06
 
 ### Added

--- a/src/pipeline/__init__.py
+++ b/src/pipeline/__init__.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 from src.pipeline.extract import NotAnAcroForm, read_acroform
 from src.pipeline.gazetteer import Gazetteer
+from src.pipeline.reason import (
+    JudgeResponse,
+    judge_cost_scope,
+    judge_description,
+    run_reasoning,
+)
 from src.pipeline.schemas import (
     ExtractedFields,
     Issue,
@@ -21,6 +27,7 @@ __all__ = [
     "Gazetteer",
     "Issue",
     "IssueKind",
+    "JudgeResponse",
     "LLMProfileInfo",
     "NotAnAcroForm",
     "PipelineResult",
@@ -28,6 +35,9 @@ __all__ = [
     "Severity",
     "Source",
     "Verdict",
+    "judge_cost_scope",
+    "judge_description",
     "read_acroform",
+    "run_reasoning",
     "run_rules",
 ]

--- a/src/pipeline/reason.py
+++ b/src/pipeline/reason.py
@@ -1,0 +1,247 @@
+"""Stage 6: LLM-judged reasoning rules.
+
+Two judges call the configured LLM profile via `judge()` and convert the
+structured verdict into `Issue` records:
+
+* `judge_cost_scope` — ``cost_scope_mismatch``: estimated cost vs scope of work
+* `judge_description` — ``description_mismatch_bank_form_3_phrasing``:
+  description text vs Form 3 / Form 8 selection
+
+`run_reasoning` runs both concurrently and never raises into the orchestrator:
+exceptions become `None` results (skipped) and ``LLMTimeout`` becomes a
+`major` Issue with ``confidence=None`` so the verdict rollup can route the
+document to manual review.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from src.pipeline.llm_profiles import LLMSchemaError, LLMTimeout, judge
+from src.pipeline.schemas import ExtractedFields, Issue, IssueKind
+
+log = logging.getLogger(__name__)
+
+DEFAULT_CONFIDENCE_THRESHOLD = 0.6
+
+COST_FIELD = "2A ESTIMATED COST OF JOB"
+PRESENT_USE_FIELD = "7A PRESENT USE"
+FORM_3_CHECKBOX = "Check Box8"
+FORM_8_CHECKBOX = "Check Box9"
+DESCRIPTION_FIELDS = (
+    "16 DESCRIPTION",
+    "16A DESCRIPTION",
+    "16B DESCRIPTION",
+    "16C DESCRIPTION",
+    "16D DESCRIPTION",
+)
+
+PROMPT_COST_SCOPE_SYSTEM = (
+    "You are a permit reviewer for the San Francisco Department of Building "
+    "Inspection. Decide whether the estimated cost of the job is plausible "
+    "for the described scope of work and present use of the property. "
+    "Flag obvious mismatches (e.g. a $1 estimate for a multi-unit "
+    "renovation, or a $500,000 estimate for replacing a single window). "
+    "Output JSON matching the JudgeResponse schema. Set verdict='flag' only "
+    "when the mismatch is clear; use confidence to express how certain you "
+    "are (0.0-1.0)."
+)
+
+PROMPT_DESCRIPTION_SYSTEM = (
+    "You are a permit reviewer for the San Francisco Department of Building "
+    "Inspection. Form 3 is for projects requiring review by other agencies "
+    "(structural, planning, fire). Form 8 is over-the-counter issuance for "
+    "minor work that needs no other-agency review. Decide whether the "
+    "description text matches the scope expected by the selected form. "
+    "Flag descriptions that read like Form-8 minor work but are filed on "
+    "Form 3 (or vice versa). Output JSON matching the JudgeResponse schema. "
+    "Set verdict='flag' only when the mismatch is clear; use confidence to "
+    "express how certain you are (0.0-1.0)."
+)
+
+
+class JudgeResponse(BaseModel):
+    """Structured verdict returned by every Stage 6 LLM judge."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    verdict: Literal["ok", "flag"]
+    confidence: float = Field(ge=0.0, le=1.0)
+    message: str
+
+
+def _str(value: object) -> str | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    s = str(value).strip()
+    return s or None
+
+
+def _description_text(fields: ExtractedFields) -> str:
+    parts = [_str(fields.get(name)) for name in DESCRIPTION_FIELDS]
+    return " ".join(p for p in parts if p)
+
+
+def _description_field_label(fields: ExtractedFields) -> str:
+    """Return the first description field that holds a value, else the canonical name."""
+    for name in DESCRIPTION_FIELDS:
+        if _str(fields.get(name)):
+            return name
+    return DESCRIPTION_FIELDS[0]
+
+
+def _selected_form(fields: ExtractedFields) -> str:
+    form_3 = bool(fields.get(FORM_3_CHECKBOX))
+    form_8 = bool(fields.get(FORM_8_CHECKBOX))
+    if form_3 and not form_8:
+        return "Form 3 (other agencies review required)"
+    if form_8 and not form_3:
+        return "Form 8 (over-the-counter issuance)"
+    if form_3 and form_8:
+        return "Both Form 3 and Form 8 selected (ambiguous)"
+    return "Neither Form 3 nor Form 8 selected"
+
+
+def _build_cost_scope_user_prompt(fields: ExtractedFields) -> str:
+    cost = _str(fields.get(COST_FIELD)) or "(blank)"
+    present_use = _str(fields.get(PRESENT_USE_FIELD)) or "(blank)"
+    description = _description_text(fields) or "(blank)"
+    return (
+        f"Estimated cost of job: {cost}\n"
+        f"Present use of property: {present_use}\n"
+        f"Description of work: {description}\n"
+    )
+
+
+def _build_description_user_prompt(fields: ExtractedFields) -> str:
+    description = _description_text(fields) or "(blank)"
+    return (
+        f"Selected form: {_selected_form(fields)}\nDescription of work: {description}\n"
+    )
+
+
+def _timeout_issue(kind: IssueKind, field: str, value: str | None) -> Issue:
+    return Issue(
+        kind=kind,
+        severity="major",
+        field=field,
+        value=value,
+        message="LLM timeout — manual review required",
+        source="llm",
+        confidence=None,
+    )
+
+
+async def _run_judge(
+    *,
+    kind: IssueKind,
+    field: str,
+    value: str | None,
+    system: str,
+    user: str,
+    profile: str,
+    threshold: float,
+) -> Issue | None:
+    try:
+        verdict = await judge(profile, system=system, user=user, schema=JudgeResponse)
+    except LLMTimeout:
+        log.warning("stage-6 judge timed out: kind=%s profile=%s", kind, profile)
+        return _timeout_issue(kind, field, value)
+    except LLMSchemaError:
+        log.warning(
+            "stage-6 judge returned malformed payload: kind=%s profile=%s",
+            kind,
+            profile,
+        )
+        return None
+
+    if not isinstance(verdict, JudgeResponse):
+        log.warning("stage-6 judge returned unexpected schema type: %s", type(verdict))
+        return None
+    if verdict.verdict != "flag":
+        return None
+    if verdict.confidence < threshold:
+        log.info(
+            "stage-6 judge below confidence threshold: kind=%s confidence=%.2f",
+            kind,
+            verdict.confidence,
+        )
+        return None
+
+    return Issue(
+        kind=kind,
+        severity="major",
+        field=field,
+        value=value,
+        message=verdict.message,
+        source="llm",
+        confidence=verdict.confidence,
+    )
+
+
+async def judge_cost_scope(
+    fields: ExtractedFields,
+    profile: str,
+    *,
+    threshold: float = DEFAULT_CONFIDENCE_THRESHOLD,
+) -> Issue | None:
+    """Judge whether ``2A ESTIMATED COST OF JOB`` is plausible for the scope."""
+    return await _run_judge(
+        kind="cost_scope_mismatch",
+        field=COST_FIELD,
+        value=_str(fields.get(COST_FIELD)),
+        system=PROMPT_COST_SCOPE_SYSTEM,
+        user=_build_cost_scope_user_prompt(fields),
+        profile=profile,
+        threshold=threshold,
+    )
+
+
+async def judge_description(
+    fields: ExtractedFields,
+    profile: str,
+    *,
+    threshold: float = DEFAULT_CONFIDENCE_THRESHOLD,
+) -> Issue | None:
+    """Judge whether the description matches the selected form's expected scope."""
+    return await _run_judge(
+        kind="description_mismatch_bank_form_3_phrasing",
+        field=_description_field_label(fields),
+        value=_description_text(fields) or None,
+        system=PROMPT_DESCRIPTION_SYSTEM,
+        user=_build_description_user_prompt(fields),
+        profile=profile,
+        threshold=threshold,
+    )
+
+
+async def run_reasoning(
+    fields: ExtractedFields,
+    profile: str,
+    *,
+    threshold: float = DEFAULT_CONFIDENCE_THRESHOLD,
+) -> list[Issue]:
+    """Run all Stage 6 judges concurrently. Always returns a list; never raises.
+
+    Each judge is wrapped so a crash in one cannot affect the other. Unexpected
+    exceptions are logged and skipped; ``LLMTimeout`` is converted to an Issue
+    inside `_run_judge`.
+    """
+    results = await asyncio.gather(
+        judge_cost_scope(fields, profile, threshold=threshold),
+        judge_description(fields, profile, threshold=threshold),
+        return_exceptions=True,
+    )
+
+    issues: list[Issue] = []
+    for result in results:
+        if isinstance(result, BaseException):
+            log.error("stage-6 judge raised unexpectedly: %r", result)
+            continue
+        if result is not None:
+            issues.append(result)
+    return issues

--- a/tests/pipeline/test_reason.py
+++ b/tests/pipeline/test_reason.py
@@ -1,0 +1,275 @@
+"""Tests for Stage 6 LLM reasoning judges.
+
+`judge()` is mocked at the boundary so no live LLM traffic occurs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.pipeline import reason as reason_mod
+from src.pipeline.llm_profiles import LLMSchemaError, LLMTimeout
+from src.pipeline.reason import (
+    DEFAULT_CONFIDENCE_THRESHOLD,
+    JudgeResponse,
+    judge_cost_scope,
+    judge_description,
+    run_reasoning,
+)
+
+
+def _fields(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "2A ESTIMATED COST OF JOB": "$120000",
+        "7A PRESENT USE": "apartments",
+        "16 DESCRIPTION": "renovate kitchen and add new partition wall",
+        "Check Box8": False,
+        "Check Box9": True,
+    }
+    base.update(overrides)
+    return base
+
+
+def _patch_judge(monkeypatch, response):
+    """Replace `reason.judge` with a stub that returns / raises `response`.
+
+    `response` is either a JudgeResponse, a callable returning one, or an
+    Exception instance to raise.
+    """
+
+    async def fake_judge(profile, *, system, user, schema):
+        assert schema is JudgeResponse
+        value = response(system=system, user=user) if callable(response) else response
+        if isinstance(value, BaseException):
+            raise value
+        return value
+
+    monkeypatch.setattr(reason_mod, "judge", fake_judge)
+
+
+@pytest.mark.asyncio
+async def test_judge_cost_scope_clean_returns_none(monkeypatch):
+    _patch_judge(
+        monkeypatch,
+        JudgeResponse(verdict="ok", confidence=0.9, message="plausible"),
+    )
+    assert await judge_cost_scope(_fields(), "cloud-fast") is None
+
+
+@pytest.mark.asyncio
+async def test_judge_cost_scope_flagged_emits_major_issue(monkeypatch):
+    _patch_judge(
+        monkeypatch,
+        JudgeResponse(
+            verdict="flag",
+            confidence=0.92,
+            message="$1 is implausible for a multi-unit kitchen renovation",
+        ),
+    )
+    issue = await judge_cost_scope(
+        _fields(**{"2A ESTIMATED COST OF JOB": "$1"}), "cloud-fast"
+    )
+
+    assert issue is not None
+    assert issue.kind == "cost_scope_mismatch"
+    assert issue.severity == "major"
+    assert issue.source == "llm"
+    assert issue.field == "2A ESTIMATED COST OF JOB"
+    assert issue.value == "$1"
+    assert issue.confidence == pytest.approx(0.92)
+    assert "implausible" in issue.message
+
+
+@pytest.mark.asyncio
+async def test_judge_cost_scope_low_confidence_suppressed(monkeypatch):
+    _patch_judge(
+        monkeypatch,
+        JudgeResponse(verdict="flag", confidence=0.3, message="maybe off"),
+    )
+    assert await judge_cost_scope(_fields(), "cloud-fast") is None
+
+
+@pytest.mark.asyncio
+async def test_judge_cost_scope_threshold_override(monkeypatch):
+    _patch_judge(
+        monkeypatch,
+        JudgeResponse(verdict="flag", confidence=0.55, message="leaning flag"),
+    )
+    # Default threshold (0.6) suppresses; lowering to 0.5 lets it through.
+    assert await judge_cost_scope(_fields(), "cloud-fast") is None
+    issue = await judge_cost_scope(_fields(), "cloud-fast", threshold=0.5)
+    assert issue is not None and issue.kind == "cost_scope_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_judge_cost_scope_timeout_emits_partial_issue(monkeypatch):
+    _patch_judge(monkeypatch, LLMTimeout("boom"))
+    issue = await judge_cost_scope(_fields(), "cloud-fast")
+
+    assert issue is not None
+    assert issue.kind == "cost_scope_mismatch"
+    assert issue.severity == "major"
+    assert issue.source == "llm"
+    assert issue.confidence is None
+    assert "manual review" in issue.message.lower()
+
+
+@pytest.mark.asyncio
+async def test_judge_cost_scope_schema_error_skipped(monkeypatch):
+    _patch_judge(monkeypatch, LLMSchemaError("bad json"))
+    assert await judge_cost_scope(_fields(), "cloud-fast") is None
+
+
+@pytest.mark.asyncio
+async def test_cost_scope_prompt_includes_relevant_fields(monkeypatch):
+    captured: dict[str, str] = {}
+
+    def stub(*, system: str, user: str) -> JudgeResponse:
+        captured["system"] = system
+        captured["user"] = user
+        return JudgeResponse(verdict="ok", confidence=0.9, message="ok")
+
+    _patch_judge(monkeypatch, stub)
+    await judge_cost_scope(_fields(), "cloud-fast")
+
+    assert "permit reviewer" in captured["system"].lower()
+    assert "$120000" in captured["user"]
+    assert "apartments" in captured["user"]
+    assert "renovate kitchen" in captured["user"]
+
+
+@pytest.mark.asyncio
+async def test_judge_description_clean_returns_none(monkeypatch):
+    _patch_judge(
+        monkeypatch,
+        JudgeResponse(verdict="ok", confidence=0.85, message="matches form"),
+    )
+    assert await judge_description(_fields(), "cloud-fast") is None
+
+
+@pytest.mark.asyncio
+async def test_judge_description_flagged_emits_issue(monkeypatch):
+    _patch_judge(
+        monkeypatch,
+        JudgeResponse(
+            verdict="flag",
+            confidence=0.78,
+            message="reads like Form 8 minor work but filed on Form 3",
+        ),
+    )
+    fields = _fields(**{"Check Box8": True, "Check Box9": False})
+    issue = await judge_description(fields, "cloud-fast")
+
+    assert issue is not None
+    assert issue.kind == "description_mismatch_bank_form_3_phrasing"
+    assert issue.severity == "major"
+    assert issue.source == "llm"
+    assert issue.field == "16 DESCRIPTION"
+    assert issue.value == "renovate kitchen and add new partition wall"
+    assert issue.confidence == pytest.approx(0.78)
+
+
+@pytest.mark.asyncio
+async def test_judge_description_low_confidence_suppressed(monkeypatch):
+    _patch_judge(
+        monkeypatch,
+        JudgeResponse(verdict="flag", confidence=0.4, message="weak signal"),
+    )
+    assert await judge_description(_fields(), "cloud-fast") is None
+
+
+@pytest.mark.asyncio
+async def test_judge_description_timeout_emits_partial_issue(monkeypatch):
+    _patch_judge(monkeypatch, LLMTimeout("slow"))
+    issue = await judge_description(_fields(), "cloud-fast")
+
+    assert issue is not None
+    assert issue.kind == "description_mismatch_bank_form_3_phrasing"
+    assert issue.confidence is None
+    assert "manual review" in issue.message.lower()
+
+
+@pytest.mark.asyncio
+async def test_description_prompt_reflects_form_selection(monkeypatch):
+    captured: dict[str, str] = {}
+
+    def stub(*, system: str, user: str) -> JudgeResponse:
+        captured["user"] = user
+        return JudgeResponse(verdict="ok", confidence=0.9, message="ok")
+
+    _patch_judge(monkeypatch, stub)
+    await judge_description(
+        _fields(**{"Check Box8": True, "Check Box9": False}), "cloud-fast"
+    )
+    assert "Form 3" in captured["user"]
+
+    captured.clear()
+    _patch_judge(monkeypatch, stub)
+    await judge_description(
+        _fields(**{"Check Box8": False, "Check Box9": True}), "cloud-fast"
+    )
+    assert "Form 8" in captured["user"]
+
+
+@pytest.mark.asyncio
+async def test_run_reasoning_returns_empty_when_both_clean(monkeypatch):
+    _patch_judge(
+        monkeypatch,
+        JudgeResponse(verdict="ok", confidence=0.95, message="ok"),
+    )
+    assert await run_reasoning(_fields(), "cloud-fast") == []
+
+
+@pytest.mark.asyncio
+async def test_run_reasoning_collects_both_issues(monkeypatch):
+    def stub(*, system: str, user: str) -> JudgeResponse:
+        # Both prompts are flagged with high confidence.
+        return JudgeResponse(
+            verdict="flag",
+            confidence=0.9,
+            message=("cost scope" if "Estimated cost" in user else "description"),
+        )
+
+    _patch_judge(monkeypatch, stub)
+    issues = await run_reasoning(_fields(), "cloud-fast")
+    kinds = {i.kind for i in issues}
+    assert kinds == {
+        "cost_scope_mismatch",
+        "description_mismatch_bank_form_3_phrasing",
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_reasoning_never_raises_on_unexpected_exception(monkeypatch):
+    async def boom(profile, *, system, user, schema):
+        raise RuntimeError("network on fire")
+
+    monkeypatch.setattr(reason_mod, "judge", boom)
+    # Must return an empty list, not raise.
+    assert await run_reasoning(_fields(), "cloud-fast") == []
+
+
+@pytest.mark.asyncio
+async def test_run_reasoning_one_judge_timeout_other_clean(monkeypatch):
+    call_log: list[str] = []
+
+    async def fake_judge(profile, *, system, user, schema):
+        if "Estimated cost" in user:
+            call_log.append("cost")
+            raise LLMTimeout("slow")
+        call_log.append("description")
+        return JudgeResponse(verdict="ok", confidence=0.9, message="ok")
+
+    monkeypatch.setattr(reason_mod, "judge", fake_judge)
+    issues = await run_reasoning(_fields(), "cloud-fast")
+
+    assert len(issues) == 1
+    assert issues[0].kind == "cost_scope_mismatch"
+    assert issues[0].confidence is None
+    assert set(call_log) == {"cost", "description"}
+
+
+def test_default_threshold_is_six_tenths():
+    assert DEFAULT_CONFIDENCE_THRESHOLD == 0.6


### PR DESCRIPTION
## summary

- Adds `src/pipeline/reason.py` with `judge_cost_scope`, `judge_description`, and `run_reasoning(fields, profile)`.
- `judge_cost_scope` emits the `cost_scope_mismatch` issue kind, judging `'2A ESTIMATED COST OF JOB'` against `'7A PRESENT USE'` and the `16/16A-D DESCRIPTION` fields.
- `judge_description` emits the `description_mismatch_bank_form_3_phrasing` issue kind, judging the description against the Form 3 / Form 8 selection encoded by `Check Box8` / `Check Box9`.
- Both judges call `judge()` from `llm_profiles` with a `JudgeResponse` Pydantic schema (`verdict ∈ {ok, flag}`, `confidence ∈ [0, 1]`, `message`). Results below a configurable confidence threshold (default `0.6`) are suppressed.
- `run_reasoning` runs both concurrently via `asyncio.gather(return_exceptions=True)` and **never raises into the orchestrator**. On `LLMTimeout` it emits a `severity=major`, `source=llm`, `confidence=None` Issue with a manual-review message so the verdict rollup can still route the document. `LLMSchemaError` and any unexpected exception are logged and skipped.
- Re-exports the new public symbols from `src.pipeline`.
- Adds `tests/pipeline/test_reason.py` (17 tests). All `judge()` calls are mocked at the boundary — no live LLM traffic in CI.

## why

Stage 6 implements the two LLM-judged mutation kinds that the dataset's `major` flavor leans on. The deterministic rules in Stage 5 cannot detect cost-vs-scope or description-vs-form-type mismatches because both require semantic judgement. This unblocks the orchestrator (PIPE-7), which composes Stages 4–6 into the end-to-end pipeline and the `POST /documents/process` endpoint.

The "never raise into the orchestrator" contract is deliberate: a single timeout or schema error from gpt-4o-mini must not fail the whole document run, but it must also not silently pass — hence the `confidence=None` partial Issue on timeout, which the verdict rollup can route to manual review.

## test plan

- [x] `uv run pytest tests/pipeline/ -v` — 78 passed (17 new, 61 existing)
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run ruff format --check src/ tests/` — clean
- [x] No live LLM calls in CI (`judge()` is mocked at the boundary in every test)
- [x] CHANGELOG.md updated under `## 2026-05-07`