### PR TITLE
fix: repair broken classifications fixture path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Notable changes to DocQFlow are recorded here so reviewers, teammates, and AI agents can quickly see what was added or changed and when.
 
+## 2026-05-09
+
+### Fixed
+
+- `tests/test_classifications.py::test_get_classification_fields_returns_nested_completeness`: replaced a `FORM_3_8_FILLED = data/permit-3-8/permit_202604089128.pdf` corpus reference with a synthetic in-memory fixture (`filled_form_3_8_pdf_bytes` in `tests/conftest.py`). The corpus PDF lived in the gitignored `data/` tree and was not present on a clean clone, so the test failed locally with `FileNotFoundError`. The new `_make_form_3_8_widget_pdf()` helper builds a one-page PDF whose AcroForm widget names mirror `_FIELD_MAP` in `src/api/pdf_fields.py`, so a round-trip through `extract_form_3_8_fields` returns exactly the values the test asserts (`application_number`, `project_address`, `parcel_number`, `estimated_cost`, `contractor_name`, `license_number`) and `evaluate_completeness` returns `passed=True, missing=[]`. CI itself stayed green only because the unrelated `trained_pipeline` fixture skips when `models/model.joblib` is absent — the failure surfaced for any developer running locally with a trained model.
+
 ## 2026-05-08
 
 ### Added

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,6 +85,50 @@ def sample_pdf_bytes() -> bytes:
     )
 
 
+def _make_form_3_8_widget_pdf(field_values: dict[str, str]) -> bytes:
+    """Build a one-page PDF whose AcroForm widgets are named per Form 3-8.
+
+    Widget names mirror the lookup keys in ``src/api/pdf_fields.py``, so a
+    round-trip through ``extract_form_3_8_fields`` returns exactly
+    ``field_values``. The page itself stays blank — the extractor reads
+    widget metadata, not rendered text.
+    """
+    doc = fitz.open()
+    page = doc.new_page()
+    y = 72
+    for name, value in field_values.items():
+        widget = fitz.Widget()
+        widget.field_name = name
+        widget.field_type = fitz.PDF_WIDGET_TYPE_TEXT
+        widget.field_value = value
+        widget.rect = fitz.Rect(72, y, 360, y + 16)
+        page.add_widget(widget)
+        y += 24
+    data = doc.tobytes()
+    doc.close()
+    return data
+
+
+@pytest.fixture
+def filled_form_3_8_pdf_bytes() -> bytes:
+    """A synthetic Form 3-8 with every required completeness field populated.
+
+    Replaces a corpus fixture that lived in the gitignored ``data/`` tree.
+    Values match the assertions in
+    ``test_get_classification_fields_returns_nested_completeness``.
+    """
+    return _make_form_3_8_widget_pdf(
+        {
+            "APPLICATION NUMBER": "202604089128",
+            "1 STREET ADDRESS OF JOB BLOCK  LOT": "2130 Harrison St #9",
+            "1 BLOCK & LOT": "3573/056",
+            "2A ESTIMATED COST OF JOB": "$29,100",
+            "14 CONTRACTOR": "MINT CONSTRUCTION INC",
+            "14C CSLB": "1143205",
+        }
+    )
+
+
 @pytest.fixture
 def blank_pdf_bytes() -> bytes:
     """A valid PDF whose page has no extractable text."""

--- a/tests/test_classifications.py
+++ b/tests/test_classifications.py
@@ -6,7 +6,6 @@ import asyncio
 from pathlib import Path
 
 DATA = Path(__file__).resolve().parent.parent / "data"
-FORM_3_8_FILLED = DATA / "permit-3-8" / "permit_202604089128.pdf"
 
 
 def test_get_classification_metadata(client, sample_pdf_bytes):
@@ -89,12 +88,25 @@ def test_get_classification_404(client):
     assert r2.status_code == 404
 
 
-def test_get_classification_fields_returns_nested_completeness(client):
-    """A real filled Form 3-8 round-trips into AcroForm extraction + completeness."""
-    pdf_bytes = FORM_3_8_FILLED.read_bytes()
+def test_get_classification_fields_returns_nested_completeness(
+    client, filled_form_3_8_pdf_bytes
+):
+    """A filled Form 3-8 round-trips into AcroForm extraction + completeness.
+
+    Uses a synthetic in-memory PDF whose AcroForm widget names match the
+    production extractor in ``src/api/pdf_fields.py``. The corpus PDF this
+    test originally referenced lived under the gitignored ``data/`` tree,
+    so the test failed locally on any clone without that fixture.
+    """
     r = client.post(
         "/api/predict",
-        files={"file": (FORM_3_8_FILLED.name, pdf_bytes, "application/pdf")},
+        files={
+            "file": (
+                "permit_202604089128.pdf",
+                filled_form_3_8_pdf_bytes,
+                "application/pdf",
+            )
+        },
     )
     assert r.status_code == 200, r.text
     cid = r.json()["id"]


### PR DESCRIPTION
## Summary
- `tests/test_classifications.py::test_get_classification_fields_returns_nested_completeness` was reading `data/permit-3-8/permit_202604089128.pdf`, which doesn't exist on a clean clone (`data/` is gitignored). It failed locally with `FileNotFoundError`.
- New `filled_form_3_8_pdf_bytes` fixture in `tests/conftest.py` builds a synthetic one-page PDF via `fitz`, with AcroForm widgets named per `_FIELD_MAP` in `src/api/pdf_fields.py`. A round-trip through `extract_form_3_8_fields` + `evaluate_completeness` returns the exact values the test already asserts.
- The test now takes the fixture instead of `Path.read_bytes()`. Module-level `FORM_3_8_FILLED` constant removed; `DATA` retained because `test_get_classification_fields_lists_missing_on_blank_template` still consumes it.
- CI stayed green because `trained_pipeline` skips when `models/model.joblib` is absent — the failure surfaced for any developer running locally with a trained model.

Closes docqflow-dua.

## Test plan
- [x] `uv run pytest tests/test_classifications.py -v` — 10 passed (was 9 passed / 1 failed)
- [x] `uv run pytest -q` — 139 passed, 3 skipped (was 138 passed / 1 failed / 3 skipped)
- [x] `uv run ruff check .` and `uv run ruff format --check .` — clean
- [x] `coderabbit review --agent --type uncommitted` — 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved test failure caused by missing test data dependency.

* **Tests**
  * Improved test data generation for more consistent and reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->